### PR TITLE
[FEAT] Client#initialize now takes an optional api_key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    thecurrencycloud (0.1)
+    thecurrencycloud (0.5)
       hashie (~> 1.0)
       httparty (~> 0.8)
       json
@@ -12,17 +12,16 @@ GEM
   specs:
     fakeweb (1.3.0)
     hashie (1.2.0)
-    httparty (0.8.3)
-      multi_json (~> 1.0)
-      multi_xml
+    httparty (0.12.0)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     jnunemaker-matchy (0.4.0)
-    json (1.7.5)
+    json (1.8.1)
     metaclass (0.0.1)
-    mime-types (1.19)
+    mime-types (2.0)
     mocha (0.10.0)
       metaclass (~> 0.0.1)
-    multi_json (1.3.6)
-    multi_xml (0.5.1)
+    multi_xml (0.5.5)
     rake (0.9.2.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)

--- a/lib/thecurrencycloud.rb
+++ b/lib/thecurrencycloud.rb
@@ -11,6 +11,7 @@ require 'thecurrencycloud/client'
 require 'thecurrencycloud/price'
 require 'thecurrencycloud/trade'
 require 'thecurrencycloud/payment'
+require 'thecurrencycloud/beneficiary'
 require 'thecurrencycloud/bank'
 
 module TheCurrencyCloud

--- a/lib/thecurrencycloud.rb
+++ b/lib/thecurrencycloud.rb
@@ -65,7 +65,7 @@ module TheCurrencyCloud
   class TheCurrencyCloud
     include HTTParty
     debug_output $stdout
-
+    RestClient.log = $stdout
     class Parser::DealWithTheCurrencyCloudInvalidJson < HTTParty::Parser
       # The thecurrencycloud API returns an ID as a string when a 201 Created
       # response is returned. Unfortunately this is invalid json.

--- a/lib/thecurrencycloud.rb
+++ b/lib/thecurrencycloud.rb
@@ -33,11 +33,11 @@ module TheCurrencyCloud
     def environment(env)
       case env.to_sym
       when :demo
-        uri = "https://devapi.thecurrencycloud.com/api/en/v1.0"
+        uri = "https://devapi.thecurrencycloudr.com/api/en/v1.0"
       when :ref
-        uri = "http://refapi.thecurrencycloud.com/api/en/v1.0"
+        uri = "http://refapi.thecurrencycloudr.com/api/en/v1.0"
       else
-        uri = "https://api.thecurrencycloud.com/api/en/v1.0"
+        uri = "https://api.thecurrencycloudr.com/api/en/v1.0"
       end
       TheCurrencyCloud.base_uri uri
     end

--- a/lib/thecurrencycloud/beneficiary.rb
+++ b/lib/thecurrencycloud/beneficiary.rb
@@ -1,0 +1,5 @@
+module TheCurrencyCloud
+  # Represents a Beneficiary
+  class Beneficiary < Hashie::Mash
+  end
+end

--- a/lib/thecurrencycloud/client.rb
+++ b/lib/thecurrencycloud/client.rb
@@ -15,7 +15,7 @@ module TheCurrencyCloud
 
     def prices_market(ccy_pair,options={})
       response = get "prices/market/#{ccy_pair.upcase}", options
-      mash = TheCurrencyCloud::Price.new(response)
+      mash = Price.new(response)
       return mash.data
     end
 
@@ -23,14 +23,14 @@ module TheCurrencyCloud
       side = convert_sell_sym(side)
       options.merge!(:buy_currency => buy_currency, :sell_currency => sell_currency, :side  => side, :amount => amount)
       response = TheCurrencyCloud.post_form("/#{token}/prices/client_quote", options)
-      mash = TheCurrencyCloud::Price.new(response)
+      mash = Price.new(response)
       return mash.data
     end
 
     # Returns a list of trades
     def trades(options={})
       response = TheCurrencyCloud.get("/#{token}/trades",query: options)
-      mash = TheCurrencyCloud::Trade.new(response)
+      mash = Trade.new(response)
       mash.data.collect{|d| Trade.new(d)}
     end
 
@@ -38,7 +38,7 @@ module TheCurrencyCloud
     def trade_execute(options)
       side = convert_sell_sym(options[:side])
       response = TheCurrencyCloud.post_form("/#{token}/trade/execute", options.merge(:side => side))
-      mash = TheCurrencyCloud::Trade.new(response)
+      mash = Trade.new(response)
       return mash.data
     end
 
@@ -46,13 +46,13 @@ module TheCurrencyCloud
     def trade_execute_with_payment(options)
       side = convert_sell_sym(options[:side])
       response = TheCurrencyCloud.post_form("/#{token}/trade/execute_with_payment", options.merge(:side => side))
-      mash = TheCurrencyCloud::Trade.new(response)
+      mash = Trade.new(response)
       return mash.data
     end
 
     def trade(trade_id)
       response = TheCurrencyCloud.get("/#{token}/trade/#{trade_id}")
-      mash = TheCurrencyCloud::Trade.new(response)
+      mash = Trade.new(response)
       return mash.data
     end
 
@@ -66,7 +66,7 @@ module TheCurrencyCloud
     def payment(trade_id,options={})
       # /api/en/v1.0/:token/payment/:payment_id
       response = TheCurrencyCloud.get("/#{token}/payment/#{trade_id}")
-      mash = TheCurrencyCloud::Payment.new(response)
+      mash = Payment.new(response)
       return mash.data
     end
 
@@ -76,7 +76,7 @@ module TheCurrencyCloud
     end
 
     def add_payment(options)
-      TheCurrencyCloud::Payment.new(TheCurrencyCloud.post_form("/#{token}/payment/add", options))
+      Payment.new(TheCurrencyCloud.post_form("/#{token}/payment/add", options))
     end
 
     def update_payment(id, options)
@@ -86,7 +86,7 @@ module TheCurrencyCloud
     def bank_accounts
       # /api/en/v1.0/:token/bank_accounts
       response = TheCurrencyCloud.get("/#{token}/bank_accounts")
-      response.parsed_response['data'].collect{|d| TheCurrencyCloud::Bank.new(d)}
+      response.parsed_response['data'].collect{|d| Bank.new(d)}
     end
 
     alias :beneficiaries :bank_accounts
@@ -94,14 +94,21 @@ module TheCurrencyCloud
     def beneficiary(id)
       # /api/en/v1.0/:token/bank_account/:beneficiary_id
       response = TheCurrencyCloud.get("/#{token}/beneficiary/#{id}")
-      mash = TheCurrencyCloud::Bank.new(response)
+      mash = Bank.new(response)
       return mash.data
     end
 
     def beneficiary_required_details(currency, destination_country_code)
       # /api/en/v1.0/:token/beneficiaries/required_fields
       response = TheCurrencyCloud.get("/#{token}/beneficiaries/required_fields?ccy=#{currency}&destination_country_code=#{destination_country_code}")
-      mash = TheCurrencyCloud::Beneficiary.new(response)
+      mash = Beneficiary.new(response)
+      return mash.data.collect(&:required).flatten.uniq
+    end
+
+    def beneficiary_validate_details(options = {})
+      query_string = options.to_query
+      response = TheCurrencyCloud.get("/#{token}/beneficiary/validate_details?#{query_string}")
+      mash = Beneficiary.new(response)
       return mash.data
     end
 

--- a/lib/thecurrencycloud/client.rb
+++ b/lib/thecurrencycloud/client.rb
@@ -15,7 +15,7 @@ module TheCurrencyCloud
 
     def prices_market(ccy_pair,options={})
       response = get "prices/market/#{ccy_pair.upcase}", options
-      mash = Price.new(response)
+      mash = TheCurrencyCloud::Price.new(response)
       return mash.data
     end
 
@@ -23,14 +23,14 @@ module TheCurrencyCloud
       side = convert_sell_sym(side)
       options.merge!(:buy_currency => buy_currency, :sell_currency => sell_currency, :side  => side, :amount => amount)
       response = TheCurrencyCloud.post_form("/#{token}/prices/client_quote", options)
-      mash = Price.new(response)
+      mash = TheCurrencyCloud::Price.new(response)
       return mash.data
     end
 
     # Returns a list of trades
     def trades(options={})
       response = TheCurrencyCloud.get("/#{token}/trades",query: options)
-      mash = Trade.new(response)
+      mash = TheCurrencyCloud::Trade.new(response)
       mash.data.collect{|d| Trade.new(d)}
     end
 
@@ -38,7 +38,7 @@ module TheCurrencyCloud
     def trade_execute(options)
       side = convert_sell_sym(options[:side])
       response = TheCurrencyCloud.post_form("/#{token}/trade/execute", options.merge(:side => side))
-      mash = Trade.new(response)
+      mash = TheCurrencyCloud::Trade.new(response)
       return mash.data
     end
 
@@ -46,13 +46,13 @@ module TheCurrencyCloud
     def trade_execute_with_payment(options)
       side = convert_sell_sym(options[:side])
       response = TheCurrencyCloud.post_form("/#{token}/trade/execute_with_payment", options.merge(:side => side))
-      mash = Trade.new(response)
+      mash = TheCurrencyCloud::Trade.new(response)
       return mash.data
     end
 
     def trade(trade_id)
       response = TheCurrencyCloud.get("/#{token}/trade/#{trade_id}")
-      mash = Trade.new(response)
+      mash = TheCurrencyCloud::Trade.new(response)
       return mash.data
     end
 
@@ -66,7 +66,7 @@ module TheCurrencyCloud
     def payment(trade_id,options={})
       # /api/en/v1.0/:token/payment/:payment_id
       response = TheCurrencyCloud.get("/#{token}/payment/#{trade_id}")
-      mash = Payment.new(response)
+      mash = TheCurrencyCloud::Payment.new(response)
       return mash.data
     end
 
@@ -76,7 +76,7 @@ module TheCurrencyCloud
     end
 
     def add_payment(options)
-      Payment.new(TheCurrencyCloud.post_form("/#{token}/payment/add", options))
+      TheCurrencyCloud::Payment.new(TheCurrencyCloud.post_form("/#{token}/payment/add", options))
     end
 
     def update_payment(id, options)
@@ -86,7 +86,7 @@ module TheCurrencyCloud
     def bank_accounts
       # /api/en/v1.0/:token/bank_accounts
       response = TheCurrencyCloud.get("/#{token}/bank_accounts")
-      response.parsed_response['data'].collect{|d| Bank.new(d)}
+      response.parsed_response['data'].collect{|d| TheCurrencyCloud::Bank.new(d)}
     end
 
     alias :beneficiaries :bank_accounts
@@ -94,14 +94,14 @@ module TheCurrencyCloud
     def beneficiary(id)
       # /api/en/v1.0/:token/bank_account/:beneficiary_id
       response = TheCurrencyCloud.get("/#{token}/beneficiary/#{id}")
-      mash = Bank.new(response)
+      mash = TheCurrencyCloud::Bank.new(response)
       return mash.data
     end
 
     def beneficiary_required_details(currency, destination_country_code)
       # /api/en/v1.0/:token/beneficiaries/required_fields
       response = TheCurrencyCloud.get("/#{token}/beneficiaries/required_fields?ccy=#{currency}&destination_country_code=#{destination_country_code}")
-      mash = Beneficiary.new(response)
+      mash = TheCurrencyCloud::Beneficiary.new(response)
       return mash.data
     end
 

--- a/lib/thecurrencycloud/client.rb
+++ b/lib/thecurrencycloud/client.rb
@@ -98,6 +98,24 @@ module TheCurrencyCloud
       return mash.data
     end
 
+    def update_beneficiary(beneficiary_id, beneficiary_details)
+      response = TheCurrencyCloud.post_form("/#{token}/beneficiary/#{beneficiary_id}", beneficiary_details)
+      mash = Beneficiary.new(response)
+      return mash.data
+    end
+
+    def beneficiaries
+      response = TheCurrencyCloud.get("/#{token}/beneficiaries")
+      mash = Beneficiary.new(response)
+      return mash.data
+    end
+
+    def create_beneficiary(beneficiary_details)
+      response = TheCurrencyCloud.post_form("/#{token}/beneficiary/new", beneficiary_details)
+      mash = Beneficiary.new(response)
+      return mash.data
+    end
+
     def beneficiary_required_details(currency, destination_country_code)
       # /api/en/v1.0/:token/beneficiaries/required_fields
       response = TheCurrencyCloud.get("/#{token}/beneficiaries/required_fields?ccy=#{currency}&destination_country_code=#{destination_country_code}")

--- a/lib/thecurrencycloud/client.rb
+++ b/lib/thecurrencycloud/client.rb
@@ -98,6 +98,13 @@ module TheCurrencyCloud
       return mash.data
     end
 
+    def beneficiary_required_details(currency, destination_country_code)
+      # /api/en/v1.0/:token/beneficiaries/required_fields
+      response = TheCurrencyCloud.get("/#{token}/beneficiaries/required_fields", {ccy: currency, destination_country_code: destination_country_code})
+      mash = Beneficiary.new(response)
+      return mash.data
+    end
+
     def bank_required_fields(currency, destination_country_code)
         # /api/en/v1.0/:token/bank_accounts/required_fields
     end

--- a/lib/thecurrencycloud/client.rb
+++ b/lib/thecurrencycloud/client.rb
@@ -100,7 +100,7 @@ module TheCurrencyCloud
 
     def beneficiary_required_details(currency, destination_country_code)
       # /api/en/v1.0/:token/beneficiaries/required_fields
-      response = TheCurrencyCloud.get("/#{token}/beneficiaries/required_fields", {ccy: currency, destination_country_code: destination_country_code})
+      response = TheCurrencyCloud.get("/#{token}/beneficiaries/required_fields?ccy=#{currency}&destination_country_code=#{destination_country_code}")
       mash = Beneficiary.new(response)
       return mash.data
     end

--- a/lib/thecurrencycloud/client.rb
+++ b/lib/thecurrencycloud/client.rb
@@ -56,6 +56,11 @@ module TheCurrencyCloud
       return mash.data
     end
 
+    def settlement_account(trade_id)
+      response = TheCurrencyCloud.get("/#{token}/trade/#{trade_id}/settlement_account")
+      mash = Trade.new(response)
+      return mash
+    end
     # Returns a list of payments
     def payments(options={})
       # /api/en/v1.0/:token/payments

--- a/lib/thecurrencycloud/client.rb
+++ b/lib/thecurrencycloud/client.rb
@@ -5,9 +5,10 @@ require 'rest_client'
 module TheCurrencyCloud
   # Represents a client and associated functionality.
   class Client
-    attr_reader :client_id, :token
+    attr_reader :client_id, :api_key, :token
 
-    def initialize(client_id)
+    def initialize(client_id, api_key = nil)
+      @api_key = api_key
       @client_id = client_id
       @token = authenticate(client_id)
     end
@@ -118,7 +119,7 @@ module TheCurrencyCloud
     private
 
     def authenticate(login_id)
-      response = TheCurrencyCloud.post_form("/authentication/token/new", { :login_id => login_id, :api_key => TheCurrencyCloud.api_key})
+      response = TheCurrencyCloud.post_form("/authentication/token/new", { :login_id => login_id, :api_key => @api_key || TheCurrencyCloud.api_key})
       mash = Hashie::Mash.new(response)
       return mash.data
     end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -10,6 +10,11 @@ class ClientTest < Test::Unit::TestCase
       @client.client_id.should == '321iuhiuhi1u23hi2u3'
     end
 
+    should "accept a token as a param" do
+      @client = TheCurrencyCloud::Client.new('321iuhiuhi1u23hi2u3', '32323232323223')
+      @client.api_key.should == '32323232323223'
+    end
+
     should "set a token" do
       @client.token.should == 'd58440e120d6012dc05423001a48acdf'
     end


### PR DESCRIPTION
Added an option for Client#new to accept a 2nd parameter for api_key, allowing developers to use a different API key for every request - multi tenancy app support.
